### PR TITLE
Fix templates packaging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-model-builder-tests
-version = 1.0.2
+version = 1.0.3
 description =
 authors = Ronald Krist <krist@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
`templates` directory should be a python package to be included in the built wheel package.
This PR fixes it by adding `__init__` to the dir.