### PR TITLE
Support for setting opensearch from the environment

### DIFF
--- a/oarepo_model_builder_tests/templates/conftest.py.jinja2
+++ b/oarepo_model_builder_tests/templates/conftest.py.jinja2
@@ -37,6 +37,12 @@ def app_config(app_config):
         "RECORDS_REFRESOLVER_STORE"
     ] = "invenio_jsonschemas.proxies.current_refresolver_store"
     app_config["RATELIMIT_AUTHENTICATED_USER"] = "200 per second"
+    app_config["SEARCH_HOSTS"] = [
+        {
+            'host': os.environ.get('SEARCH_HOSTS_HOST', 'localhost'),
+            'port': os.environ.get('SEARCH_HOSTS_PORT', '9200'),
+        }
+    ]
     return app_config
 
 

--- a/oarepo_model_builder_tests/templates/conftest.py.jinja2
+++ b/oarepo_model_builder_tests/templates/conftest.py.jinja2
@@ -39,8 +39,8 @@ def app_config(app_config):
     app_config["RATELIMIT_AUTHENTICATED_USER"] = "200 per second"
     app_config["SEARCH_HOSTS"] = [
         {
-            'host': os.environ.get('SEARCH_HOSTS_HOST', 'localhost'),
-            'port': os.environ.get('SEARCH_HOSTS_PORT', '9200'),
+            'host': os.environ.get('OPENSEARCH_HOST', 'localhost'),
+            'port': os.environ.get('OPENSEARCH_PORT', '9200'),
         }
     ]
     return app_config

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = oarepo-model-builder-tests
-version = 2.0.0
+version = 2.0.1
 description =
 authors = Ronald Krist <krist@cesnet.cz>
 readme = README.md


### PR DESCRIPTION
Added reading environment variables to get the opensearch host and port:

OPENSEARCH_HOST
OPENSEARCH_PORT
